### PR TITLE
[KT1-7] Criar OwnedException

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/OwnedException.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/OwnedException.kt
@@ -1,3 +1,3 @@
 package framework
 
-class OwnedException(message: String) : Exception(message)
+open class OwnedException(message: String) : Exception(message)

--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/OwnedException.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/OwnedException.kt
@@ -1,0 +1,3 @@
+package framework
+
+class OwnedException(message: String) : Exception(message)


### PR DESCRIPTION
Criar uma classe que herde a exceção padrão do Kotlin, a `Exception`. Utilizaremos essa classe customizada sempre que precisarmos criar erros próprios para nossas regras de negócio.

Ex.: Ao inputar o valor do salário bruto, caso ele seja negativo, devemos validar isso e levantar uma exceção, mas essa exceção precisa ser customizada, então criaremos algo do tipo:

```kotlin
class InvalidRawSalaryException(message: String) : OwnedException(message)
//          vamos utilizar aqui a classe que você criou ⬆️
```

### Critérios de aceitação

- [x]  A classe está em um package adequado para sua função.
- [x]  A classe herda de `Exception`
- [x]  A classe possui um parâmetro do tipo `String` em seu construtor.