### PR TITLE
[KT1-11] Cria object ExceptionHandler

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/exceptions/DoesNotStartsWithException.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/exceptions/DoesNotStartsWithException.kt
@@ -1,5 +1,3 @@
 package framework.exceptions
 
-import framework.OwnedException
-
 class DoesNotStartsWithException(message: String) : OwnedException(message)

--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/exceptions/ExceptionHandler.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/exceptions/ExceptionHandler.kt
@@ -1,7 +1,7 @@
 package framework.exceptions
 
 object ExceptionHandler {
-    fun isOwnedException(exception: Exception) {
+    fun handleException(exception: Exception) {
         when (exception) {
             is OwnedException -> println(exception.message)
             else -> println("Tivemos um problema para calcular seu salário líquido, contate os mega-devs da DevPass")

--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/exceptions/ExceptionHandler.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/exceptions/ExceptionHandler.kt
@@ -1,0 +1,10 @@
+package framework.exceptions
+
+object ExceptionHandler {
+    fun isOwnedException(exception: Exception) {
+        when (exception) {
+            is OwnedException -> println(exception.message)
+            else -> println("Tivemos um problema para calcular seu salário líquido, contate os mega-devs da DevPass")
+        }
+    }
+}

--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/exceptions/OwnedException.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/exceptions/OwnedException.kt
@@ -1,3 +1,3 @@
-package framework
+package framework.exceptions
 
 open class OwnedException(message: String) : Exception(message)


### PR DESCRIPTION
Criar um `object` responsável por tratar mensagens de erro provenientes do fluxo do sistema.

Esse `object` deve ter um método que recebe um parâmetro do tipo `Exception` e valide se ela é do tipo `OwnedException` ou não.

Se ela for do tipo `OwnedException`, deve ser feito o print do erro, caso contrário, deve ser feito log do erro, e mostrar uma mensagem genérica em vez disso, algo como “Tivemos um problema para calcular seu salário líquido, contate os mega-devs da DevPass”

### Critérios de aceitação

- [x]  Implementação utiliza clausula `when` para fazer o tratamento da mensagem de erro.

---

> Obs.: Movi as Exceptions para o modulo `exceptions`