### PR TITLE
[KT1-10] Add object to read IRRF from resource

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/irrf/IRRFRangeManager.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/irrf/IRRFRangeManager.kt
@@ -1,0 +1,25 @@
+package irrf
+
+import framework.ResourceReader
+
+object IRRFRangeManager {
+
+    fun readFileIRRF(fileName: String) : List<IRRFRange> {
+        val listOfValues = ResourceReader.readAsList(fileName)
+
+        val irrfRanges = listOfValues.map { lines ->
+            createIRRFRange(lines.split("@"))
+        }
+
+        return irrfRanges
+    }
+
+    fun createIRRFRange(listOfValues: List<String>) : IRRFRange{
+        return IRRFRange(
+                minimumValue = listOfValues[0].toDouble(),
+                maximumValue = if (listOfValues[1] == "MAX") Double.MAX_VALUE else listOfValues[1].toDouble(),
+                rate = listOfValues[2].toDouble(),
+                deductableParcel = listOfValues[3].toDouble(),
+        )
+    }
+}


### PR DESCRIPTION
## Descrição 

Cria um `object`, nomeado como IRRFRangeManager, que faz a leitura do arquivo `faixasIRRF.txt` utilizando `ResourceReader` e retorna uma lista do `data class` de faixa de IRRF.