### PR TITLE
mudando o logger de property para object

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/Loggable.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/Loggable.kt
@@ -2,7 +2,7 @@ package framework
 
 import framework.interfaces.ILogger
 open class Loggable {
-    val logger = object : ILogger {
+    object logger: ILogger {
         override fun error(message: String) {
             println("[Error] $message")
         }


### PR DESCRIPTION
### O que é

Originalmente, `logger` era uma propriedade da `open class Loggable`, no entanto, precisamos que só exista uma implementação de `ILogger` durante o ciclo de vida da aplicação para uma *feature* futura.

Para isso, `Loggable` precisa ser alterado para que `logger` deixe de ser uma propriedade, e vire um `object` dentro de `Loggable`.

### Critérios de aceitação

- [ ]  `logger` deixou de ser uma `property` e virou um `object` dentro de `Loggable`.