### PR TITLE
[KT1-18] Refactor ResourceReader.kt

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/ResourceReader.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/ResourceReader.kt
@@ -6,16 +6,13 @@ import framework.interfaces.IResourceReader
 object ResourceReader : IResourceReader, Loggable() {
 
     override fun readAsList(fileName: String): List<String> {
-
-        var lines: List<String> = listOf<String>()
-
-        try {
+        return try {
+            if (!fileName.startsWith("/"))
+                throw DoesNotStartsWithException("File path must be initialized with a /")
             this::class.java.getResource(fileName).readText().lines()
         } catch (e: Exception) {
-            logger.error("File path must be initialized with a /")
-            throw DoesNotStartsWithException("File path must be initialized with a /")
+            logger.error(e.message ?: "Unexpected error")
+            throw e
         }
-
-        return lines
     }
 }

--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/ResourceReader.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/ResourceReader.kt
@@ -3,16 +3,17 @@ package framework
 import framework.exceptions.DoesNotStartsWithException
 import framework.interfaces.IResourceReader
 
-object ResourceReader: IResourceReader{
+object ResourceReader : IResourceReader, Loggable() {
 
     override fun readAsList(fileName: String): List<String> {
 
-        val lines: List<String>
+        var lines: List<String> = listOf<String>()
 
-        if(fileName.startsWith("/")){
-            lines = this::class.java.getResource(fileName).readText().lines()
-        } else{
-            throw DoesNotStartsWithException(message = "File path must be initialized with a /")
+        try {
+            this::class.java.getResource(fileName).readText().lines()
+        } catch (e: Exception) {
+            logger.error("File path must be initialized with a /")
+            throw DoesNotStartsWithException("File path must be initialized with a /")
         }
 
         return lines


### PR DESCRIPTION
## Descrição 

O `object ResourceReader` foi alterado para que a função de leitura de arquivos seja envolvida em um `try/catch`.

No bloco de `catch`, é gerado log do erro, e levantada uma exceção específica que herde `OwnedException`, com uma mensagem indicando que houve falha na leitura do arquivo