### PR TITLE
contador nas mensagens de erro

### DIFF
--- a/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/Loggable.kt
+++ b/solutions/devsprint-luiz-zytkowski-1/src/main/kotlin/framework/Loggable.kt
@@ -3,16 +3,21 @@ package framework
 import framework.interfaces.ILogger
 open class Loggable {
     object logger: ILogger {
+        var counter: Int = 0
+
         override fun error(message: String) {
-            println("[Error] $message")
+            counter++
+            println("$counter [Error] $message")
         }
 
         override fun info(message: String) {
-            println("[Info] $message")
+            counter++
+            println("$counter [Info] $message")
         }
 
         override fun warn(message: String) {
-            println("[Warn] $message")
+            counter++
+            println("$counter [Warn] $message")
         }
     }
 }


### PR DESCRIPTION
[KT1-20] Alterar implementação interna de ILogger dentro de Loggable para conter um contador que atualiza a cada log gerado

### Critérios de aceitação

- [ ]  Números na ordem correta são mostrados ao lado das mensagens de log.
- [ ]  Números não repetem durante o ciclo de vida do programa.
- [ ]  **Nenhuma mensagem de log precisou ser alterada para que os números fossem mostrados na ordem.**