### PR TITLE
Adicionado metodo para manipular as exceptions

### DIFF
--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/Loggable.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/Loggable.kt
@@ -5,15 +5,15 @@ import framework.interfaces.ILogger
 open class Loggable {
     val logger = object : ILogger {
         override fun info(message: String) {
-            println("Info: $message")
+            println("[Info] $message")
         }
 
         override fun warn(message: String) {
-            println("Warn: $message")
+            println("[Warn] $message")
         }
 
         override fun error(message: String) {
-            println("Error: $message")
+            println("[Error] $message")
         }
     }
 }

--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/exceptionhandler/ExceptionHandler.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/exceptionhandler/ExceptionHandler.kt
@@ -3,21 +3,17 @@ package framework.exceptionhandler
 import framework.Loggable
 
 object ExceptionHandler : Loggable() {
-
     fun handler(ex: Exception) {
+        logger.error(ex.message.toString())
         when (ex) {
             is InvalidRawSalaryException -> {
-                println(ex.message)
-                println("Valor precisa ser numerico ex: 3559.50")
+                logger.error("Valor precisa ser numerico ex: 3559.50")
             }
             is NotFoundException -> {
-                println(ex.message)
-                println("Se o arquivo estiver no resources não esqueça da / meu caro dev")
+                logger.error("Se o arquivo estiver no resources não esqueça da / meu caro dev")
             }
-            is OwnedException -> println(ex.message)
             else -> {
-                logger.error(ex.message.toString())
-                println("Tivemos um problema para calcular seu salário líquido, contate os mega-devs da DevPass")
+                logger.error("Tivemos um problema para calcular seu salário líquido, contate os mega-devs da DevPass")
             }
         }
     }

--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/exceptionhandler/ExceptionHandler.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/exceptionhandler/ExceptionHandler.kt
@@ -1,0 +1,24 @@
+package framework.exceptionhandler
+
+import framework.Loggable
+
+object ExceptionHandler : Loggable() {
+
+    fun handler(ex: Exception) {
+        when (ex) {
+            is InvalidRawSalaryException -> {
+                println(ex.message)
+                println("Valor precisa ser numerico ex: 3559.50")
+            }
+            is NotFoundException -> {
+                println(ex.message)
+                println("Se o arquivo estiver no resources não esqueça da / meu caro dev")
+            }
+            is OwnedException -> println(ex.message)
+            else -> {
+                logger.error(ex.message.toString())
+                println("Tivemos um problema para calcular seu salário líquido, contate os mega-devs da DevPass")
+            }
+        }
+    }
+}

--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/exceptionhandler/OwnedException.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/exceptionhandler/OwnedException.kt
@@ -1,9 +1,6 @@
 package framework.exceptionhandler
 
-open class OwnedException (message: String) : Exception(message)
-
+open class OwnedException(message: String) : Exception(message)
 class ThereIsNoValueFromIndex(message: String) : OwnedException(message)
-
 class NotFoundException(message: String) : OwnedException(message)
-
-class InvalidRawSalaryException (message : String) : OwnedException(message)
+class InvalidRawSalaryException(message: String) : OwnedException(message)

--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/exceptionhandler/OwnedException.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/exceptionhandler/OwnedException.kt
@@ -1,5 +1,3 @@
 package framework.exceptionhandler
 
-open class OwnedException (message: String) : Exception(message) {
-
-}
+open class OwnedException (message: String) : Exception(message)


### PR DESCRIPTION
### O que é

Criar um `object` responsável por tratar mensagens de erro provenientes do fluxo do sistema.

Esse `object` deve ter um método que recebe um parâmetro do tipo `Exception` e valide se ela é do tipo `OwnedException` ou não.

Mostrar mensagem para cada tipo de Exception através da class  [`Loggable` ]

Se ela for do tipo `OwnedException`, deve ser feito o print do erro, caso contrário, deve ser feito log do erro, e mostrar uma mensagem genérica em vez disso, algo como “Tivemos um problema para calcular seu salário líquido, contate os mega-devs da DevPass”

Adicional: Tratar cada subtype de OwnedException de forma unitária.

### Critérios de aceitação

- [x]  Implementação utiliza clausula `when` para fazer o tratamento da mensagem de erro.