### PR TITLE
Alterando classe Loggable para que “logger” deixe de ser uma propried…

### DIFF
--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/Loggable.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/Loggable.kt
@@ -3,7 +3,7 @@ package framework
 import framework.interfaces.ILogger
 
 open class Loggable {
-    val logger = object : ILogger {
+    object logger : ILogger {
         override fun info(message: String) {
             println("[Info] $message")
         }


### PR DESCRIPTION
Originalmente, `logger` era uma propriedade da `open class Loggable`, no entanto, precisamos que só exista uma implementação de `ILogger` durante o ciclo de vida da aplicação para uma *feature* futura.

Para isso, `Loggable` precisa ser alterado para que `logger` deixe de ser uma propriedade, e vire um `object` dentro de `Loggable`.