### PR TITLE
Aplicar Static Factory Method na criação das classes Calculator

### DIFF
--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/salarioLiquido/LiquidSalaryCalculator.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/salarioLiquido/LiquidSalaryCalculator.kt
@@ -1,16 +1,14 @@
 package salarioLiquido
 
+import framework.exceptionhandler.NotFoundException
+import framework.interfaces.ICalculable
 import inss.INSSCalculator
 import irrf.IRRFCalculator
 
-class LiquidSalaryCalculator(
-    private val inssCalculator: INSSCalculator = INSSCalculator(),
-    private val irrfCalculator: IRRFCalculator = IRRFCalculator()
-) {
-
+class LiquidSalaryCalculator {
     fun calculate(grossSalary: Double): NetSalaryResult {
-        val deductionINSS = inssCalculator.calculate(grossSalary)
-        val deductionIRRF = irrfCalculator.calculate(grossSalary - deductionINSS)
+        val deductionINSS = calculatorManager("INSS").calculate(grossSalary)
+        val deductionIRRF = calculatorManager("IRRF").calculate(grossSalary - deductionINSS)
         val netSalary = grossSalary - deductionINSS - deductionIRRF
 
         return NetSalaryResult(
@@ -19,5 +17,15 @@ class LiquidSalaryCalculator(
             discountINSS = deductionINSS,
             discountIRRF = deductionIRRF
         )
+    }
+
+    companion object {
+        fun calculatorManager(type: String): ICalculable {
+            return when (type) {
+                "INSS" -> INSSCalculator()
+                "IRRF" -> IRRFCalculator()
+                else -> throw NotFoundException("Tipo de Cálculo não encontrado: $type")
+            }
+        }
     }
 }


### PR DESCRIPTION
### O que é

Com a abstração das classes `IRRFCalculator` e `INSSCalculator`  criada, agora é possível termos mais implementações específicas relacionado à calculos, por Exemplo: Calculo de Ferias, Calculo 13 entre outros.

A classe `LiquidSalaryCalculator` está responsável por instanciar qual o tipo de Cálculo ela precisa, ela faz isso através de seu construtor. Porém não é responsabilidade dela saber como fazer isso, uma vez que pode ter várias formas de cálculo.

Para aumentar a escabilidade você deve implementar o padrão de designer Static Factory Method.

Você criará uma classe que possui um método static, no Kotlin utilizamos o companion object para isso.

Sua função deve receber como parâmetro, no formato String, o tipo de Calculo que deverá ser criado, e deve retornar uma implementação de `Calculable`.

Exemplo:

```kotlin
interface ChessPiece {
    fun howMove()
}

class Pawn() : ChessPiece {
    override fun howMove() {
        println("Eu posso mover apenas uma casa")
    }
}

data class Queen() : ChessPiece {
    override fun howMove() {
        println("Eu posso mover em qualquer direcao")
    }
}

class PieceFactory {
    companion object {
        fun createPiece(type: String): ChessPiece {
            return when (type) {
                'q' -> Queen()
                'p' -> Pawn()
                // ...
                else -> throw RuntimeException("Unknown piece: $type")
            }
        }
    }
}
```

### Critérios de aceitação

- [x]  Você criou a classe que será responsável pela criação de objetos do tipo `Calculable`
- [x]  Você alterou a classe `LiquidSalaryCalculator` para acessar a Factory, retornando os tipos de instâncias corretamente.