### PR TITLE
Alterando implementação interna de ILogger dentro de Loggable para co…

### DIFF
--- a/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/Loggable.kt
+++ b/solutions/devsprint-michel-ferreira-2/src/main/kotlin/framework/Loggable.kt
@@ -2,7 +2,18 @@ package framework
 
 import framework.interfaces.ILogger
 
+fun main() {
+    Loggable().logCounter()
+}
+
 open class Loggable {
+    fun logCounter() {
+        logger.info("Oi")
+        logger.warn("Oi")
+        logger.error("Oi")
+        logger.info("Oi")
+    }
+
     object logger : ILogger {
         override fun info(message: String) {
             println("[Info] $message")


### PR DESCRIPTION
A ideia é que queremos gerar um contador no começo das mensagens de log que indique a ordem das chamadas de logs, para isso, a implementação de `ILogger` dentro da `open class Loggable` precisa ser alterada para contar com essa *feature*.

Você pode criar uma `property` do tipo `Int` dentro da implementação de `ILogger` para controlar o número referente à última mensagem de log disparada.

Você não deve alterar nenhuma mensagem de log já codificada no programa, deve modificar somente o `object logger` dentro da `open class Loggable`